### PR TITLE
:sparkles: Legger til oppgittebarn ved innsending

### DIFF
--- a/pages/api/innsending/soknadinnsending.ts
+++ b/pages/api/innsending/soknadinnsending.ts
@@ -1,5 +1,5 @@
 import { beskyttetApi } from 'auth/beskyttetApi';
-import { logError, tokenXApiProxy } from '@navikt/aap-felles-utils';
+import { logError } from '@navikt/aap-felles-utils';
 import { NextApiRequest, NextApiResponse } from 'next';
 import metrics from 'utils/metrics';
 import { ErrorMedStatus } from 'lib/utils/api/ErrorMedStatus';
@@ -86,10 +86,22 @@ const handler = beskyttetApi(async (req: NextApiRequest, res: NextApiResponse) =
   const { formatMessage } = getIntl();
   const søknadPdf = mapSøknadToPdf(søknad, new Date(), formatMessage, []);
 
+  /**
+   * oppgitteBarn brukes i behandlingsflyt
+   */
   try {
     await sendSoknadViaAapInnsending(
       {
-        soknad: { ...søknad, version: SOKNAD_VERSION, etterspurtDokumentasjon },
+        soknad: {
+          ...søknad,
+          version: SOKNAD_VERSION,
+          etterspurtDokumentasjon,
+          oppgitteBarn: {
+            identer: søknad.manuelleBarn?.map((barn) => {
+              return { identifikator: barn.fnr };
+            }),
+          },
+        },
         kvittering: søknadPdf,
         filer,
       },

--- a/types/Soknad.ts
+++ b/types/Soknad.ts
@@ -101,6 +101,14 @@ export interface SoknadVedlegg {
   ANNET?: Vedlegg[];
 }
 
+interface Ident {
+  identifikator?: string;
+}
+
+interface OppgitteBarn {
+  identer?: Ident[];
+}
+
 export interface Soknad {
   sykepenger?: JaEllerNei;
   yrkesskade?: JaEllerNei;
@@ -115,6 +123,7 @@ export interface Soknad {
   andreUtbetalinger?: AndreUtbetalinger;
   barn?: Barn[];
   manuelleBarn?: ManuelleBarn[];
+  oppgitteBarn?: OppgitteBarn;
   tilleggsopplysninger?: string;
   ferie?: Ferie;
   vedlegg?: SoknadVedlegg;


### PR DESCRIPTION
I behandlingsflyt så har vi et steg som dukker opp dersom dette feltet er populert. Vi bruker et nytt felt slik at vi slipper migrering fra manuelleBarn til oppgitteBarn og tilhørende endringer på typene.