### PR TITLE
AAP-1158 mer detaljer på manuelt oppgitte barn

### DIFF
--- a/components/pageComponents/standard/Barnetillegg/AddBarnModal.tsx
+++ b/components/pageComponents/standard/Barnetillegg/AddBarnModal.tsx
@@ -256,7 +256,7 @@ export const AddBarnModal = ({
             </div>
 
             {barn.ukjentFnr && (
-              <Alert variant="warning">
+              <Alert variant="info">
                 {formatMessage({ id: 'søknad.barnetillegg.leggTilBarn.modal.ukjentFnr.warning' })}
               </Alert>
             )}

--- a/components/pageComponents/standard/Barnetillegg/AddBarnModalValidation.test.ts
+++ b/components/pageComponents/standard/Barnetillegg/AddBarnModalValidation.test.ts
@@ -16,6 +16,7 @@ describe('AddBarnModal validation', () => {
       },
       fødseldato: sub(new Date(), { years: 1 }),
       relasjon: Relasjon.FORELDER,
+      fnr: '01020312345',
     };
     const result = await schema.validate(barn, { abortEarly: false }).catch((err) => err);
     expect(result).toStrictEqual(barn);
@@ -29,8 +30,38 @@ describe('AddBarnModal validation', () => {
       },
       fødseldato: add(new Date(), { years: 1 }),
       relasjon: Relasjon.FORELDER,
+      fnr: '01020312345',
     };
     const result = await schema.validate(barn, { abortEarly: false }).catch((err) => err);
     expect(result.errors.length).toBe(1);
+  });
+
+  it('should validate missing fnr', async () => {
+    const barn = {
+      navn: {
+        fornavn: 'Fornavn',
+        etternavn: 'Etternavn',
+      },
+      fødseldato: sub(new Date(), { years: 1 }),
+      relasjon: Relasjon.FORELDER,
+      fnr: undefined,
+    };
+    const result = await schema.validate(barn, { abortEarly: false }).catch((err) => err);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('should allow missing fnr if ukjentFnr is true', async () => {
+    const barn = {
+      navn: {
+        fornavn: 'Fornavn',
+        etternavn: 'Etternavn',
+      },
+      fødseldato: sub(new Date(), { years: 1 }),
+      relasjon: Relasjon.FORELDER,
+      fnr: undefined,
+      ukjentFnr: true
+    };
+    const result = await schema.validate(barn, { abortEarly: false }).catch((err) => err);
+    expect(result).toEqual(barn);
   });
 });

--- a/pages/api/innsending/soknadinnsending.ts
+++ b/pages/api/innsending/soknadinnsending.ts
@@ -7,7 +7,7 @@ import { isFunctionalTest, isMock } from 'utils/environments';
 import { createIntl } from 'react-intl';
 import { flattenMessages, messages } from 'utils/message';
 import links from 'translations/links.json';
-import { Soknad } from 'types/Soknad';
+import { ManueltOppgittBarn, Soknad } from 'types/Soknad';
 import { mapSøknadToPdf } from 'utils/api';
 import { getAndreUtbetalingerSchema } from 'components/pageComponents/standard/AndreUtbetalinger/AndreUtbetalinger';
 import { getBehandlerSchema } from 'components/pageComponents/standard/Behandlere/EndreEllerLeggTilBehandlerModal';
@@ -21,6 +21,7 @@ import { deleteCache } from 'mock/mellomlagringsCache';
 import { simpleTokenXProxy } from 'lib/utils/api/simpleTokenXProxy';
 import { IncomingMessage } from 'http';
 import { søknadVedleggStateTilFilArray } from 'utils/vedlegg';
+import { formatNavn } from 'utils/StringFormatters';
 
 // TODO: Sjekke om vi må generere pdf på samme språk som bruker har valgt når de fyller ut søknaden
 function getIntl() {
@@ -96,15 +97,22 @@ const handler = beskyttetApi(async (req: NextApiRequest, res: NextApiResponse) =
           ...søknad,
           version: SOKNAD_VERSION,
           etterspurtDokumentasjon,
-          ...(søknad.manuelleBarn &&
-            søknad.manuelleBarn.length > 0 &&
-            søknad.manuelleBarn.some((barn) => barn.fnr) && {
+          ...(!!søknad.manuelleBarn?.length && {
               oppgitteBarn: {
                 identer: søknad.manuelleBarn
                   .filter((barn) => barn.fnr)
                   .map((barn) => ({
                     identifikator: barn.fnr,
                   })),
+                barn: søknad.manuelleBarn.map(
+                  (barn) =>
+                    ({
+                      navn: formatNavn(barn.navn),
+                      fødselsdato: barn.fødseldato,
+                      ident: barn.fnr ? { identifikator: barn.fnr } : undefined,
+                      relasjon: barn.relasjon,
+                    }) as ManueltOppgittBarn,
+                ),
               },
             }),
         },

--- a/translations/nb.json
+++ b/translations/nb.json
@@ -563,11 +563,16 @@
             }
           },
           "fødselsnummer": {
-            "label": "Fødselsnummer / D-nummer",
+            "label": "Fødselsnummer eller D-nummer",
             "validation": {
-              "required": "Du må fylle inn barnets fødselsnummer / D-nummer.",
-              "numberCharacters": "Fødselsnummer / D-nummer må være 11 siffer."
+              "required": "Du må fylle inn barnets fødselsnummer eller D-nummer.",
+              "numberCharacters": "Fødselsnummer eller D-nummer må være 11 siffer.",
+              "matches": "Fødselsnummer eller D-nummer må være 11 siffer."
             }
+          },
+          "ukjentFnr": {
+            "label": "Barnet har ikke fødselsnummer eller D-nummer",
+            "warning": "Saksbehandlingen kan ta lenger tid når du ikke oppgir fødselsnummeret eller d-nummeret til barnet."
           },
           "fødselsdato": {
             "label": "Fødselsdato (dd.mm.åååå)",
@@ -575,11 +580,11 @@
               "required": "Du må fylle inn barnets fødselsdato. Fyll inn slik: dd.mm.åååå.",
               "min": "Du kan ikke få barnetillegg for barn over 18 år. Hvis barnet er under 18 år, må du rette opp fødselsdato.",
               "max": "Barnets fødselsdato kan ikke være etter dagens dato. Velg en fødselsdato før eller lik dagens dato",
-              "typeError": "Fødselsdato må være en gyldig dato på format dd.mm.yyyy"
+              "typeError": "Fødselsdato må være en gyldig dato på format dd.mm.åååå"
             }
           },
           "relasjon": {
-            "label": "Hvilken relasjon har du til barnet?",
+            "label": "Hva er din relasjon til barnet?",
             "validation": {
               "required": "Du må svare på hvilken relasjon du har til barnet."
             }

--- a/translations/nn.json
+++ b/translations/nn.json
@@ -563,11 +563,16 @@
             }
           },
           "fødselsnummer": {
-            "label": "Fødselsnummer/D-nummer",
+            "label": "Fødselsnummer eller D-nummer",
             "validation": {
-              "required": "Du må fylle inn fødselsnummeret/D-nummeret til barnet.",
-              "numberCharacters": "Fødselsnummeret/D-nummeret må bestå av 11 siffer."
+              "required": "Du må fylle inn fødselsnummeret eller D-nummeret til barnet.",
+              "numberCharacters": "Fødselsnummer eller D-nummer må være 11 siffer.",
+              "matches": "Fødselsnummer eller D-nummer må være 11 siffer."
             }
+          },
+          "ukjentFnr": {
+            "label": "Barnet har ikkje fødselsnummer eller D-nummer",
+            "warning": "Saksbehandlingen kan ta lenger tid når du ikkje oppgir fødselsnummeret eller d-nummeret til barnet."
           },
           "fødselsdato": {
             "label": "Fødselsdato (dd.mm.åååå)",
@@ -575,7 +580,7 @@
               "required": "Du må fylle inn fødselsdatoen til barnet. Fyll inn slik: dd.mm.åååå.",
               "min": "Du kan ikkje få barnetillegg for barn over 18 år. Dersom barnet er under 18 år, må du rette opp fødselsdatoen.",
               "max": "Fødselsdatoen til barnet kan ikkje vere etter dags dato. Vel ein fødselsdato før eller lik dags dato",
-              "typeError": "Fødselsdatoen må vera ein gyldig dato på format dd.mm.yyyy"
+              "typeError": "Fødselsdatoen må vera ein gyldig dato på format dd.mm.åååå"
             }
           },
           "relasjon": {

--- a/types/Soknad.ts
+++ b/types/Soknad.ts
@@ -107,8 +107,16 @@ interface Ident {
   identifikator?: string;
 }
 
+export interface ManueltOppgittBarn {
+  navn?: string
+  fødselsdato?: Date
+  ident?: Ident
+  relasjon?: string
+}
+
 export interface OppgitteBarn {
   identer?: Ident[];
+  barn?: ManueltOppgittBarn[];
 }
 
 export interface Soknad {

--- a/utils/environments.ts
+++ b/utils/environments.ts
@@ -9,5 +9,3 @@ export const isDev = () => process.env.RUNTIME_ENVIRONMENT === 'dev';
 
 export const clientSideIsProd = () =>
   typeof window !== 'undefined' && window.location.href.includes('www.nav.no');
-
-export const erKelvinSoknad = () => process.env.NEXT_PUBLIC_KELVIN_SOKNAD === 'enabled';


### PR DESCRIPTION
Utvidet skjema til å ta imot fødselsnummer på barnet, samt støtte for å hoppe over dette i tilfeller hvor barnet ikke har fnr/dnr. 

![Screenshot 2025-07-08 at 10 37 00](https://github.com/user-attachments/assets/4677f47c-21d4-4aef-ad82-fb698f14cda6)

![Screenshot 2025-07-08 at 10 37 13](https://github.com/user-attachments/assets/a80d79a2-ccd2-474e-bfc4-21dd442c8d4d)
