### PR TITLE
Håndterer evt tidssoneproblemer ved å sette tidspunkt eksplisitt

### DIFF
--- a/components/pageComponents/standard/Barnetillegg/AddBarnModal.tsx
+++ b/components/pageComponents/standard/Barnetillegg/AddBarnModal.tsx
@@ -130,8 +130,10 @@ export const AddBarnModal = ({
   const { formatMessage } = useIntl();
   const { setErrors, findError, clearErrors } = useFormErrors();
 
-  const parseFødselsdato = (event: React.FocusEvent<HTMLInputElement>) =>
-    parse(event.target.value, 'dd.MM.yyyy', new Date());
+  const parseFødselsdato = (event: React.FocusEvent<HTMLInputElement>) => {
+    const date = parse(event.target.value, 'dd.MM.yyyy', new Date());
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  };
 
   const parseFødselsdatoToString = () => {
     if (!barn.fødseldato) {


### PR DESCRIPTION
Ser at vi i alle fall av og til får én dag tidligere fødselsdato enn det manuelle barn har fått oppgitt. Dette skal forhåpentligvis fikse feilen.