### PR TITLE
Refaktorer til at fastlege er ett enkelt objekt eller null i stede for array

### DIFF
--- a/components/pageComponents/standard/Behandlere/Behandlere.tsx
+++ b/components/pageComponents/standard/Behandlere/Behandlere.tsx
@@ -25,8 +25,9 @@ interface Props {
 
 export const getBehandlerSchema = (formatMessage: IntlFormatters['formatMessage']) =>
   yup.object().shape({
-    fastlege: yup.array().of(
-      yup.object().shape({
+    fastlege: yup
+      .object()
+      .shape({
         erRegistrertFastlegeRiktig: yup
           .string()
           .required(
@@ -34,8 +35,8 @@ export const getBehandlerSchema = (formatMessage: IntlFormatters['formatMessage'
           )
           .oneOf([JaEllerNei.JA, JaEllerNei.NEI])
           .nullable(),
-      }),
-    ),
+      })
+      .nullable(),
   });
 export const Behandlere = ({ onBackClick }: Props) => {
   const [errors, setErrors] = useState<SøknadValidationError[] | undefined>();
@@ -109,20 +110,19 @@ export const Behandlere = ({ onBackClick }: Props) => {
           <Heading size={'small'} level={'3'}>
             {formatMessage({ id: 'søknad.helseopplysninger.registrertFastlege.title' })}
           </Heading>
-          {søknadState?.søknad?.fastlege?.length === 0 && (
+          {!søknadState?.søknad?.fastlege && (
             <BodyLong>
               {formatMessage({ id: 'søknad.helseopplysninger.registrertFastlege.ingenFastlege' })}
             </BodyLong>
           )}
-          {søknadState?.søknad?.fastlege?.map((fastlege, index) => (
+          {søknadState?.søknad?.fastlege && (
             <RegistrertBehandler
-              key={fastlege.behandlerRef}
-              index={index}
-              fastlege={fastlege}
+              key={søknadState.søknad.fastlege.behandlerRef}
+              fastlege={søknadState.søknad.fastlege}
               clearErrors={clearErrors}
-              errorMessage={findError(`fastlege[${index}].erRegistrertFastlegeRiktig`)}
+              errorMessage={findError('fastlege.erRegistrertFastlegeRiktig')}
             />
-          ))}
+          )}
         </div>
         <div>
           <Heading size={'small'} level={'3'} spacing>

--- a/components/pageComponents/standard/Behandlere/BehandlereValidation.test.ts
+++ b/components/pageComponents/standard/Behandlere/BehandlereValidation.test.ts
@@ -16,42 +16,36 @@ describe('Behandlere validation', () => {
   };
   it('ingenting registrerte behandlere', async () => {
     const form = {
-      fastlege: [],
+      fastlege: null,
     };
     const result = await schema.validate(form, { abortEarly: false }).catch((err) => err);
     expect(result).toStrictEqual(form);
   });
   it('har registrert behandler, info er riktig', async () => {
     const form = {
-      fastlege: [
-        {
-          ...fastlege,
-          erRegistrertFastlegeRiktig: JaEllerNei.JA,
-        },
-      ],
+      fastlege: {
+        ...fastlege,
+        erRegistrertFastlegeRiktig: JaEllerNei.JA,
+      },
     };
     const result = await schema.validate(form, { abortEarly: false }).catch((err) => err);
     expect(result).toStrictEqual(form);
   });
   it('har registrert behandler, info er feil', async () => {
     const form = {
-      fastlege: [
-        {
-          ...fastlege,
-          erRegistrertFastlegeRiktig: JaEllerNei.NEI,
-        },
-      ],
+      fastlege: {
+        ...fastlege,
+        erRegistrertFastlegeRiktig: JaEllerNei.NEI,
+      },
     };
     const result = await schema.validate(form, { abortEarly: false }).catch((err) => err);
     expect(result).toStrictEqual(form);
   });
   it('har registrert behandler, må svare om info er riktig', async () => {
     const form = {
-      fastlege: [
-        {
-          ...fastlege,
-        },
-      ],
+      fastlege: {
+        ...fastlege,
+      },
     };
     const result = await schema.validate(form, { abortEarly: false }).catch((err) => err);
     expect(result.errors.length).not.toBe(0);

--- a/components/pageComponents/standard/Behandlere/RegistrertBehandler.tsx
+++ b/components/pageComponents/standard/Behandlere/RegistrertBehandler.tsx
@@ -10,11 +10,10 @@ import { updateSøknadData } from 'context/soknadcontext/actions';
 
 interface Props {
   fastlege: RegistrertFastlege;
-  index: number;
   clearErrors: () => void;
   errorMessage?: string;
 }
-export const RegistrertBehandler = ({ fastlege, index, clearErrors, errorMessage }: Props) => {
+export const RegistrertBehandler = ({ fastlege, clearErrors, errorMessage }: Props) => {
   const { formatMessage } = useIntl();
   const { søknadState, søknadDispatch } = useSoknad();
 
@@ -52,8 +51,8 @@ export const RegistrertBehandler = ({ fastlege, index, clearErrors, errorMessage
         <dd>{formatTelefonnummer(fastlege.kontaktinformasjon.telefon)}</dd>
       </dl>
       <RadioGroup
-        name={`fastlege[${index}].erRegistrertFastlegeRiktig`}
-        id={`fastlege[${index}].erRegistrertFastlegeRiktig`}
+        name={'fastlege.erRegistrertFastlegeRiktig'}
+        id={'fastlege.erRegistrertFastlegeRiktig'}
         legend={formatMessage({
           id: `søknad.helseopplysninger.erRegistrertFastlegeRiktig.label`,
         })}
@@ -61,13 +60,9 @@ export const RegistrertBehandler = ({ fastlege, index, clearErrors, errorMessage
         onChange={(value) => {
           clearErrors();
           updateSøknadData(søknadDispatch, {
-            fastlege: søknadState.søknad?.fastlege?.map((behandler) => {
-              if (behandler.behandlerRef === fastlege.behandlerRef) {
-                return { ...behandler, erRegistrertFastlegeRiktig: value };
-              } else {
-                return behandler;
-              }
-            }),
+            fastlege: søknadState.søknad?.fastlege
+              ? { ...søknadState.søknad.fastlege, erRegistrertFastlegeRiktig: value }
+              : null,
           });
         }}
         error={errorMessage}

--- a/components/pageComponents/standard/Oppsummering/Oppsummering.tsx
+++ b/components/pageComponents/standard/Oppsummering/Oppsummering.tsx
@@ -272,22 +272,22 @@ const Oppsummering = ({
           hasError={behandlereHasErrors}
         >
           <>
-            {søknadState?.søknad?.fastlege?.map((fastlege, index) => (
-              <article key={'fastlege-' + index}>
+            {søknadState?.søknad?.fastlege && (
+              <article>
                 <Heading size={'small'} level={'3'}>
                   {formatMessage({ id: 'søknad.oppsummering.helseopplysninger.fastlege' })}
                 </Heading>
-                <BodyShort>{fastlege.navn}</BodyShort>
-                <BodyShort>{fastlege.kontaktinformasjon.kontor}</BodyShort>
-                <BodyShort>{fastlege.kontaktinformasjon.adresse}</BodyShort>
+                <BodyShort>{søknadState.søknad.fastlege.navn}</BodyShort>
+                <BodyShort>{søknadState.søknad.fastlege.kontaktinformasjon.kontor}</BodyShort>
+                <BodyShort>{søknadState.søknad.fastlege.kontaktinformasjon.adresse}</BodyShort>
                 <BodyShort>{`Telefon: ${formatTelefonnummer(
-                  fastlege.kontaktinformasjon.telefon,
+                  søknadState.søknad.fastlege.kontaktinformasjon.telefon,
                 )}`}</BodyShort>
                 <BodyShort>{`${formatMessage({
                   id: 'søknad.oppsummering.helseopplysninger.informasjonOmFastlege',
-                })} ${fastlege.erRegistrertFastlegeRiktig}`}</BodyShort>
+                })} ${søknadState.søknad.fastlege.erRegistrertFastlegeRiktig}`}</BodyShort>
               </article>
-            ))}
+            )}
 
             {søknadState?.søknad?.andreBehandlere?.map((behandler) => (
               <OppsummeringBehandler key={behandler.id} behandler={behandler} />

--- a/context/soknadcontext/actions.tsx
+++ b/context/soknadcontext/actions.tsx
@@ -36,7 +36,7 @@ type AddBarnIfMissing = {
 };
 type AddFastlegeIfMissing = {
   type: SoknadActionKeys.ADD_FASTLEGE_IF_MISSING;
-  payload: Fastlege[];
+  payload: Fastlege | null;
 };
 type AddRequiredVedlegg = {
   type: SoknadActionKeys.ADD_REQUIRED_VEDLEGG;
@@ -121,7 +121,7 @@ export async function removeRequiredVedlegg(
   if (vedleggType)
     dispatch({ type: SoknadActionKeys.REMOVE_REQUIRED_VEDLEGG, payload: vedleggType });
 }
-export const addFastlegeIfMissing = (dispatch: Dispatch<SoknadAction>, data: Fastlege[]) => {
+export const addFastlegeIfMissing = (dispatch: Dispatch<SoknadAction>, data: Fastlege | null) => {
   dispatch({ type: SoknadActionKeys.ADD_FASTLEGE_IF_MISSING, payload: data });
 };
 export const addBarnIfMissing = (dispatch: Dispatch<SoknadAction>, data: Barn[]) => {

--- a/context/soknadcontext/reducer.tsx
+++ b/context/soknadcontext/reducer.tsx
@@ -34,22 +34,19 @@ export function soknadReducer(state: SoknadContextState, action: SoknadAction): 
       };
     }
     case SoknadActionKeys.ADD_FASTLEGE_IF_MISSING: {
-      const oldRegistrertFastlege = state?.søknad?.fastlege || [];
-      const registrerteFastleger: RegistrertFastlege[] = structuredClone(action.payload).map(
-        (fastlege) => {
-          const eksisterende = oldRegistrertFastlege.find(
-            (e) => e?.behandlerRef === fastlege?.behandlerRef,
-          );
-          return eksisterende?.erRegistrertFastlegeRiktig
-            ? { ...fastlege, erRegistrertFastlegeRiktig: eksisterende.erRegistrertFastlegeRiktig }
-            : fastlege;
-        },
-      );
+      const eksisterende = state.søknad?.fastlege;
+      const ny = structuredClone(action.payload);
+
+      const fastlege =
+        ny && eksisterende?.behandlerRef === ny.behandlerRef
+          ? { ...ny, erRegistrertFastlegeRiktig: eksisterende.erRegistrertFastlegeRiktig }
+          : ny;
+
       return {
         ...state,
         søknad: {
           ...state.søknad,
-          fastlege: registrerteFastleger,
+          fastlege,
         },
       };
     }

--- a/lib/utils/migrerMellomlagretBehandler.test.ts
+++ b/lib/utils/migrerMellomlagretBehandler.test.ts
@@ -3,145 +3,90 @@ import { migrerMellomlagretBehandler } from 'lib/utils/migrerMellomlagretBehandl
 import { SoknadContextState } from 'context/soknadcontext/soknadContext';
 import { describe, test, expect } from 'vitest';
 
-const mellomlagretSøknadBehandlerFraOppslag: SoknadContextState = {
+const mellomlagretSøknadMedFastlegeObjekt: SoknadContextState = {
   version: 1,
   requiredVedlegg: [],
   søknad: {
-    fastlege: [
-      {
-        navn: 'Sonja Paracet Plastersen',
-        erRegistrertFastlegeRiktig: JaEllerNei.JA,
-        behandlerRef: 'd182f24b-ebca-4f44-bf86-65901ec6141b',
-        kontaktinformasjon: {
-          adresse: 'Skogveien 17, 1234 Andeby',
-          kontor: 'Andeby legekontor',
-          telefon: '99999999',
-        },
+    fastlege: {
+      navn: 'Sonja Paracet Plastersen',
+      erRegistrertFastlegeRiktig: JaEllerNei.JA,
+      behandlerRef: 'd182f24b-ebca-4f44-bf86-65901ec6141b',
+      kontaktinformasjon: {
+        adresse: 'Skogveien 17, 1234 Andeby',
+        kontor: 'Andeby legekontor',
+        telefon: '99999999',
       },
-    ],
+    },
   },
 };
 
-const mellomlagretSøknadBehandlerFraSøknadAPI: SoknadContextState = {
-  requiredVedlegg: [],
-  version: 1,
-  søknad: {
-    registrerteBehandlere: [
-      {
-        erRegistrertFastlegeRiktig: JaEllerNei.JA,
-        type: 'FASTLEGE',
-        navn: { fornavn: 'Sonja', mellomnavn: 'Paracet', etternavn: 'Plastersen' },
-        kategori: 'LEGE',
-        kontaktinformasjon: {
-          behandlerRef: 'd182f24b-ebca-4f44-bf86-65901ec6141b',
-          kontor: 'Andeby legekontor',
-          orgnummer: '999999',
-          adresse: {
-            adressenavn: 'Skogveien',
-            husnummer: '17',
-            postnummer: {
-              postnr: '1234',
-              poststed: 'Andeby',
-            },
-          },
-          telefon: '99999999',
-        },
-      },
-    ],
-  },
-};
-
-describe('migrer mellomlagret behandler', () => {
+describe('migrer mellomlagret fastlege', () => {
   describe('migrerer når', () => {
-    test('behandler kommer fra gammel struktur og spørsmål om behandler er korrekt er besvart', () => {
-      const migrertMellomlagring = migrerMellomlagretBehandler(
-        mellomlagretSøknadBehandlerFraSøknadAPI,
-      );
+    test('mellomlagret fastlege som liste normaliseres til objekt', () => {
+      const mellomlagretMedFastlegeListe: SoknadContextState = {
+        version: 1,
+        requiredVedlegg: [],
+        søknad: {
+          fastlege: [
+            {
+              navn: 'Sonja Paracet Plastersen',
+              erRegistrertFastlegeRiktig: JaEllerNei.JA,
+              behandlerRef: 'd182f24b-ebca-4f44-bf86-65901ec6141b',
+              kontaktinformasjon: {
+                adresse: 'Skogveien 17, 1234 Andeby',
+                kontor: 'Andeby legekontor',
+                telefon: '99999999',
+              },
+            },
+          ] as any,
+        },
+      };
 
-      expect(migrertMellomlagring.søknad?.fastlege).toHaveLength(1);
+      const res = migrerMellomlagretBehandler(mellomlagretMedFastlegeListe);
+      expect(Array.isArray(res.søknad?.fastlege)).toBe(false);
+      expect(res.søknad?.fastlege).toEqual(mellomlagretSøknadMedFastlegeObjekt.søknad?.fastlege);
+    });
 
-      const migrertFastlege =
-        migrertMellomlagring.søknad?.fastlege && migrertMellomlagring.søknad.fastlege[0];
-      expect(migrertFastlege).not.toBeUndefined();
+    test('tom fastlegeliste normaliseres til null', () => {
+      const mellomlagretMedTomFastlegeListe: SoknadContextState = {
+        version: 1,
+        requiredVedlegg: [],
+        søknad: {
+          fastlege: [] as any,
+        },
+      };
 
-      // @ts-ignore - Typen sier den kan være undef, men den er ikke det her.
-      const forventetBehandler = mellomlagretSøknadBehandlerFraOppslag.søknad?.fastlege[0];
-      expect(migrertMellomlagring).toEqual(mellomlagretSøknadBehandlerFraOppslag);
-      expect(migrertFastlege).toEqual(forventetBehandler);
+      const res = migrerMellomlagretBehandler(mellomlagretMedTomFastlegeListe);
+      expect(res.søknad?.fastlege).toBeNull();
     });
   });
 
   describe('migrerer ikke når', () => {
-    test('mellomlagret behandler kommer fra oppslag', () => {
-      const res = migrerMellomlagretBehandler(mellomlagretSøknadBehandlerFraOppslag);
-      expect(res).toEqual(mellomlagretSøknadBehandlerFraOppslag);
+    test('mellomlagret fastlege allerede er objekt', () => {
+      const res = migrerMellomlagretBehandler(mellomlagretSøknadMedFastlegeObjekt);
+      expect(res).toEqual(mellomlagretSøknadMedFastlegeObjekt);
     });
 
-    test('mellomlagret søknad ikke inneholder noen behandlere', () => {
-      const mellomlagretSøknadUtenRegistrertBehandler: SoknadContextState = {
-        version: 1,
-        requiredVedlegg: [],
-        søknad: {
-          registrerteBehandlere: [],
-        },
-      };
-
-      const res = migrerMellomlagretBehandler(mellomlagretSøknadUtenRegistrertBehandler);
-      expect(res.søknad?.registrerteBehandlere).toEqual([]);
-    });
-
-    test('registerteBehandlere ikke finnes', () => {
-      const mellomlagretSøknadUtenRegistrertBehandler: SoknadContextState = {
+    test('søknad mangler fastlege', () => {
+      const mellomlagretSøknadUtenFastlege: SoknadContextState = {
         version: 1,
         requiredVedlegg: [],
         søknad: {},
       };
 
-      const res = migrerMellomlagretBehandler(mellomlagretSøknadUtenRegistrertBehandler);
-      expect(res.søknad?.registrerteBehandlere).toEqual(undefined);
+      const res = migrerMellomlagretBehandler(mellomlagretSøknadUtenFastlege);
+      expect(res).toEqual(mellomlagretSøknadUtenFastlege);
     });
 
-    test('registrerteBehandlere er undefined', () => {
-      const mellomlagretSøknadUtenRegistrertBehandler: SoknadContextState = {
+    test('søknad er undefined', () => {
+      const mellomlagretSøknadUtenSøknad: SoknadContextState = {
         version: 1,
         requiredVedlegg: [],
-        søknad: {
-          registrerteBehandlere: undefined,
-        },
+        søknad: undefined,
       };
 
-      const res = migrerMellomlagretBehandler(mellomlagretSøknadUtenRegistrertBehandler);
-      expect(res.søknad?.registrerteBehandlere).toEqual(undefined);
-    });
-
-    test('behandler kommer fra soknad-api og spørsmål om behandler er korrekt ikke er besvart', () => {
-      const fastlegeSpmIkkeBesvart: any = {
-        søknad: {
-          registrerteBehandlere: [
-            {
-              type: 'FASTLEGE',
-              navn: { fornavn: 'Sonja', mellomnavn: 'Paracet', etternavn: 'Plastersen' },
-              kategori: 'LEGE',
-              kontaktinformasjon: {
-                behandlerRef: 'd182f24b-ebca-4f44-bf86-65901ec6141b',
-                kontor: 'Andeby legekontor',
-                orgnummer: '999999',
-                adresse: {
-                  adressenavn: 'Skogveien',
-                  husnummer: '17',
-                  postnummer: {
-                    postnr: '1234',
-                    poststed: 'Andeby',
-                  },
-                },
-                telefon: '99999999',
-              },
-            },
-          ],
-        },
-      };
-      const res = migrerMellomlagretBehandler(fastlegeSpmIkkeBesvart);
-      expect(res).toEqual(fastlegeSpmIkkeBesvart);
+      const res = migrerMellomlagretBehandler(mellomlagretSøknadUtenSøknad);
+      expect(res).toEqual(mellomlagretSøknadUtenSøknad);
     });
   });
 });

--- a/lib/utils/migrerMellomlagretBehandler.ts
+++ b/lib/utils/migrerMellomlagretBehandler.ts
@@ -1,4 +1,3 @@
-import { formatFullAdresse, formatNavn } from 'utils/StringFormatters';
 import { SoknadContextState } from 'context/soknadcontext/soknadContext';
 
 /**
@@ -9,37 +8,15 @@ import { SoknadContextState } from 'context/soknadcontext/soknadContext';
 export const migrerMellomlagretBehandler = (
   mellomlagretSøknad: SoknadContextState,
 ): SoknadContextState => {
-  if (
-    mellomlagretSøknad.søknad?.registrerteBehandlere &&
-    mellomlagretSøknad.søknad?.registrerteBehandlere.length > 0
-  ) {
-    const behandler = mellomlagretSøknad?.søknad?.registrerteBehandlere[0];
-
-    const behandlerErKorrektErBesvart = behandler.erRegistrertFastlegeRiktig !== undefined;
-
-    // trenger ikke migrere hvis spørsmålet om behandler ikke er besvart enda. Behandler vil da bli satt
-    // i addBehandlerIfMissing som kalles fra [step].tsx
-    if (behandlerErKorrektErBesvart) {
-      delete mellomlagretSøknad.søknad.registrerteBehandlere;
-      return {
-        ...mellomlagretSøknad,
-        søknad: {
-          ...mellomlagretSøknad.søknad,
-          fastlege: [
-            {
-              erRegistrertFastlegeRiktig: behandler?.erRegistrertFastlegeRiktig,
-              navn: formatNavn(behandler.navn),
-              behandlerRef: behandler.kontaktinformasjon.behandlerRef,
-              kontaktinformasjon: {
-                adresse: formatFullAdresse(behandler.kontaktinformasjon.adresse),
-                telefon: behandler.kontaktinformasjon.telefon,
-                kontor: behandler.kontaktinformasjon.kontor,
-              },
-            },
-          ],
-        },
-      };
-    }
+  if (Array.isArray(mellomlagretSøknad.søknad?.fastlege)) {
+    return {
+      ...mellomlagretSøknad,
+      søknad: {
+        ...mellomlagretSøknad.søknad,
+        fastlege: mellomlagretSøknad.søknad.fastlege[0] || null,
+      },
+    };
   }
+
   return mellomlagretSøknad;
 };

--- a/pages/[step].tsx
+++ b/pages/[step].tsx
@@ -49,7 +49,7 @@ interface PageProps {
   kontaktinformasjon: KrrKontaktInfo | null;
   person: Person;
   barn: Barn[];
-  fastlege: Fastlege[];
+  fastlege: Fastlege | null;
 }
 
 const Steps = ({ person, mellomlagretSøknad, kontaktinformasjon, barn, fastlege }: PageProps) => {
@@ -217,7 +217,7 @@ const hentFastlege = async (req: IncomingMessage) => {
     return await getFastlege(req);
   } catch (e) {
     logError('Noe gikk galt i kallet mot oppslag/fastlege', e);
-    return [];
+    return null;
   }
 };
 

--- a/pages/api/oppslag/fastlege.ts
+++ b/pages/api/oppslag/fastlege.ts
@@ -20,13 +20,28 @@ const Fastlege = z.object({
 
 export type Fastlege = z.infer<typeof Fastlege>;
 
+const normalizeFastlegeResponse = (data: Fastlege[] | Fastlege | null): Fastlege | null => {
+  if (data === null) {
+    return null;
+  }
+
+  if (Array.isArray(data)) {
+    if (data.length === 0) {
+      return null;
+    }
+    return data[0];
+  }
+
+  return data;
+};
+
 const handler = beskyttetApi(async (req: NextApiRequest, res: NextApiResponse) => {
   res.status(200).json(await getFastlege(req));
 });
-export const getFastlege = async (req: IncomingMessage): Promise<Fastlege[]> => {
-  if (isMock() || isDev()) return mockFastlege;
+export const getFastlege = async (req: IncomingMessage): Promise<Fastlege | null> => {
+  if (isMock() || isDev()) return normalizeFastlegeResponse(mockFastlege);
 
-  const fastlege: Fastlege = await simpleTokenXProxy({
+  const fastlege = await simpleTokenXProxy({
     url: `${process.env.OPPSLAG_URL}/fastlege`,
     prometheusPath: 'oppslag/fastlege',
     method: 'GET',
@@ -36,12 +51,13 @@ export const getFastlege = async (req: IncomingMessage): Promise<Fastlege[]> => 
     metricsTimer: metrics.backendApiDurationHistogram,
   });
 
-  const validatedResponse = z.array(Fastlege).safeParse(fastlege);
+  const validatedResponse = z.union([z.array(Fastlege), Fastlege, z.null()]).safeParse(fastlege);
   if (!validatedResponse.success) {
     logError(`oppslag/fastlege valideringsfeil: ${validatedResponse.error.message}`);
-    return [];
+    return null;
   }
-  return validatedResponse.data;
+
+  return normalizeFastlegeResponse(validatedResponse.data);
 };
 
 export default handler;

--- a/tests/unhappypath.spec.ts
+++ b/tests/unhappypath.spec.ts
@@ -310,7 +310,7 @@ test('at alle feilmeldinger skal dukke opp', async ({ page }) => {
     })
     .click();
   await expect(page).toHaveURL(
-    'http://localhost:3000/aap/soknad/4/#fastlege[0].erRegistrertFastlegeRiktig',
+    'http://localhost:3000/aap/soknad/4/#fastlege.erRegistrertFastlegeRiktig',
   );
   await page.getByLabel('Nei').check();
   await expect(

--- a/types/Soknad.ts
+++ b/types/Soknad.ts
@@ -123,11 +123,7 @@ export interface Soknad {
   sykepenger?: JaEllerNei;
   yrkesskade?: JaEllerNei;
   medlemskap?: Medlemskap;
-  /**
-   * @Deprecated
-   */
-  registrerteBehandlere?: RegistrertBehandler[];
-  fastlege?: RegistrertFastlege[];
+  fastlege?: RegistrertFastlege | null;
   andreBehandlere?: Behandler[];
   student?: Student;
   andreUtbetalinger?: AndreUtbetalinger;

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -194,22 +194,20 @@ export const mapSøknadToPdf = (
     ]);
   };
   const getRegistrerteBehandlere = (søknad?: Soknad) => {
-    if (!søknad?.fastlege?.length) {
-    }
-    const fastleger = !søknad?.fastlege?.length
+    const fastleger = !søknad?.fastlege
       ? createFritekst('Fant ingen registrert fastlege')
-      : søknad?.fastlege?.map((behandler) =>
+      : [
           createFeltgruppe([
-            ...createField('Navn', behandler?.navn),
-            ...createField('Kontor', behandler?.kontaktinformasjon?.kontor),
-            ...createField('Adresse', behandler?.kontaktinformasjon?.adresse),
-            ...createField('Telefon', behandler?.kontaktinformasjon?.telefon),
+            ...createField('Navn', søknad.fastlege?.navn),
+            ...createField('Kontor', søknad.fastlege?.kontaktinformasjon?.kontor),
+            ...createField('Adresse', søknad.fastlege?.kontaktinformasjon?.adresse),
+            ...createField('Telefon', søknad.fastlege?.kontaktinformasjon?.telefon),
             ...createField(
               formatMessage({ id: `søknad.helseopplysninger.erRegistrertFastlegeRiktig.label` }),
-              behandler?.erRegistrertFastlegeRiktig,
+              søknad.fastlege?.erRegistrertFastlegeRiktig,
             ),
           ]),
-        ) || [];
+        ];
     return createTema('Registrerte behandlere', fastleger);
   };
   const getAndreBehandlere = (søknad?: Soknad) => {


### PR DESCRIPTION
Det er kun en eller ingen fastlege. Endringen støtter at backend fortsatt returnerer en array, og støtter enkelt objekt eller null slik at backend kan endres etter denne endringen. Denne endringen gjør at fastlege-feltet i arkivert JSON-dokument endres fra array til objekt eller null.