### PR TITLE
fix: use NODE_AUTH_TOKEN in .yarnrc.yml for setup-node@v7 compatibility

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,7 +5,7 @@ npmMinimalAgeGate: 2880
 npmScopes:
   navikt:
     npmAlwaysAuth: true
-    npmAuthToken: "${NPM_AUTH_TOKEN:-}"
+    npmAuthToken: "${NODE_AUTH_TOKEN:-}"
     npmRegistryServer: "https://npm.pkg.github.com"
 
 # Sikkerhetstiltak

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Vi bruker Github sitt package registry for npm pakker, siden flere av Nav sine p
 For å kunne kjøre `yarn install` lokalt må du logge inn mot Github package registry. Legg til følgende i .bashrc eller .zshrc lokalt på din maskin:
 I .bashrc eller .zshrc:
 
-`export NPM_AUTH_TOKEN=github_pat`
+`export NODE_AUTH_TOKEN=github_pat`
 
 Hvor github_pat er din personal access token laget på github(settings -> developer settings). Husk read:packages rettighet og enable sso når du oppdaterer/lager PAT.
 


### PR DESCRIPTION
## Problem
`actions/setup-node@v7` removed the dummy `NODE_AUTH_TOKEN` export and no longer recognizes `NPM_AUTH_TOKEN`. Yarn berry reads auth directly from `.yarnrc.yml`, so the token reference must match the env var that `setup-node` sets.

## Change
Rename `NPM_AUTH_TOKEN` → `NODE_AUTH_TOKEN` in `.yarnrc.yml`.

Same fix applied in navikt/mine-aap.